### PR TITLE
Fix to overwatch and action points

### DIFF
--- a/src/TBE.Logic/Characters/Character.cs
+++ b/src/TBE.Logic/Characters/Character.cs
@@ -101,7 +101,22 @@ namespace TBE.Logic.Characters
         public Weapon UtilityWeaponEquipped { get; set; }
         public Item UtilityItemEquipped { get; set; }
         public CoverState CoverState { get; set; }
-        public bool InOverwatch { get; set; }
+        private bool _inOverwatch;
+        public bool InOverwatch
+        {
+            get
+            {
+                return _inOverwatch;
+            }
+            set
+            {
+                _inOverwatch = value;
+                if (_inOverwatch)
+                {
+                    ActionPointsCurrent = 0;
+                }
+            }
+        }
         public bool HunkeredDown { get; set; }
 
         //Records & statistics
@@ -284,11 +299,11 @@ namespace TBE.Logic.Characters
             ////    inverseMap[(int)item.X, (int)item.Y, (int)item.Z] = FieldOfView.FOV_CanNotSee;
             ////}
             ////Now that we have the inverse map, reverse it to show areas that are not visible
-                //for (int y = GameConstants.FIRST_INDEX; y < GameConstants.STANDARD_Y_DIMENSION; y++)
-                //{
-                //    for (int x = GameConstants.FIRST_INDEX; x < xMax; x++)
-                //    {
-                //        for (int z = GameConstants.FIRST_INDEX; z < zMax; z++)
+            //for (int y = GameConstants.FIRST_INDEX; y < GameConstants.STANDARD_Y_DIMENSION; y++)
+            //{
+            //    for (int x = GameConstants.FIRST_INDEX; x < xMax; x++)
+            //    {
+            //        for (int z = GameConstants.FIRST_INDEX; z < zMax; z++)
             //        {
             //            if (inverseMap[x, y, z] != "")
             //            {

--- a/src/TBE.Logic/Characters/CharacterMovement.cs
+++ b/src/TBE.Logic/Characters/CharacterMovement.cs
@@ -41,7 +41,7 @@ namespace TBE.Logic.Characters
             {
                 opponentCharacters = opponentTeam.Characters;
             }
-            int totalActionPoints = TotalOverwatchActionPoints(opponentCharacters);
+            int totalOverwatchCharacters = TotalOverwatchCharacterCount(opponentCharacters);
             int i = 0;
             foreach (Vector3 step in pathFindingResult.Path)
             {
@@ -76,7 +76,7 @@ namespace TBE.Logic.Characters
                     result.FOVMap = (string[,,])characterMoving.FOVMap.Clone();
                 }
                 result.FOVMapString = MapCore.GetMapStringWithMapMask(map, result.FOVMap);
-                if (opponentCharacters != null && totalActionPoints > GameConstants.DEAD_HITPOINTS)
+                if (opponentCharacters != null && totalOverwatchCharacters > GameConstants.DEAD_HITPOINTS)
                 {
                     (List<EncounterResult>, bool) overWatchResult = Overwatch(map, characterMoving, diceRolls, opponentCharacters);
                     encounters.AddRange(overWatchResult.Item1);
@@ -101,7 +101,7 @@ namespace TBE.Logic.Characters
                     }
                     else
                     {
-                        totalActionPoints = TotalOverwatchActionPoints(opponentCharacters);
+                        totalOverwatchCharacters = TotalOverwatchCharacterCount(opponentCharacters);
                     }
                 }
                 if (log.Count > GameConstants.DEAD_HITPOINTS)
@@ -142,7 +142,7 @@ namespace TBE.Logic.Characters
                     List<Vector3> fov = FieldOfView.GetFieldOfView(map, character.Location, character.FOVRange);
                     foreach (Vector3 fovLocation in fov)
                     {
-                        if (character.ActionPointsCurrent > GameConstants.DEAD_HITPOINTS && fovLocation == characterMoving.Location)
+                        if (fovLocation == characterMoving.Location)
                         {
                             //Act
                             result = Encounter.AttackCharacter(map, character, character.WeaponEquipped, characterMoving, diceRolls);
@@ -162,7 +162,7 @@ namespace TBE.Logic.Characters
             return (results, true);
         }
 
-        private static int TotalOverwatchActionPoints(List<Character> overWatchedCharacters)
+        private static int TotalOverwatchCharacterCount(List<Character> overWatchedCharacters)
         {
             int total = 0;
             if (overWatchedCharacters != null)
@@ -171,7 +171,7 @@ namespace TBE.Logic.Characters
                 {
                     if (item.InOverwatch == true)
                     {
-                        total += item.ActionPointsCurrent;
+                        total++;
                     }
                 }
             }

--- a/src/TBE.Tests/Map/OverwatchTests.cs
+++ b/src/TBE.Tests/Map/OverwatchTests.cs
@@ -144,8 +144,10 @@ Jethro is moving from <6, 0, 1> to <6, 0, 0>
             Vector3 destination = new(6, 0, 0);
             Character fred = CharacterPool.CreateFredHero(map, new(0, 0, 0));
             fred.InOverwatch = true;
+            Assert.AreEqual(0, fred.ActionPointsCurrent);
             Character harry = CharacterPool.CreateHarryHero(map, new(5, 0, 5));
             harry.InOverwatch = true;
+            Assert.AreEqual(0, harry.ActionPointsCurrent);
             Team team1 = new(1);
             team1.Characters.Add(fred);
             team1.Characters.Add(harry);
@@ -167,6 +169,8 @@ Jethro is moving from <6, 0, 1> to <6, 0, 0>
             Assert.AreEqual(10, harry.XP);
             Assert.AreEqual(1, movementResults.Count);
             Assert.AreEqual(2, movementResults[0].OverwatchEncounterResults.Count);
+            Assert.AreEqual(0, fred.ActionPointsCurrent);
+            Assert.AreEqual(0, harry.ActionPointsCurrent);
             string log = @"
 Jethro is moving from <8, 0, 8> to <8, 0, 7>
 Harry is attacking with Sniper Rifle, targeted on Jethro


### PR DESCRIPTION
This pull request updates the overwatch mechanic in the game's logic to ensure that characters entering overwatch immediately lose all their action points, and simplifies how overwatch is processed during movement. The most important changes are grouped below: